### PR TITLE
Add command logging and update `serialport` library

### DIFF
--- a/lib/Controller.js
+++ b/lib/Controller.js
@@ -191,6 +191,13 @@ Controller.prototype._sendCommand = function(command, cb) {
     var self = this;
 
     self.port.write(command + '\r\n', function(err) {
+        if (err) {
+            self.emit('log', util.format(
+                'Error sending command "%s": %s',
+                command,
+                err.message
+            ));
+        }
         if (typeof cb === 'function') {
             cb(err);
         }

--- a/lib/Controller.js
+++ b/lib/Controller.js
@@ -33,8 +33,9 @@ function Controller(settings) {
         parser   : SerialPort.parsers.readline('\n')
     });
 
-    self.port.on('open', self._onPortOpen.bind(self));
-    self.port.on('data', self._onPortData.bind(self));
+    self.port.on('open' , self._onPortOpen.bind(self));
+    self.port.on('error', self._onPortError.bind(self));
+    self.port.on('data' , self._onPortData.bind(self));
 
     self._isFirstLine = true;
 
@@ -214,6 +215,20 @@ Controller.prototype._onPortOpen = function() {
         }
         self.emit('log', 'serial port open');
     });
+};
+
+Controller.prototype._onPortError = function(err) {
+    var self = this;
+
+    console.error(
+        'Serial port error:  %s',
+        err.message
+    );
+    console.error(
+        'Check the serial device name and make sure it\'s connected.'
+    );
+    console.error();
+    throw err;
 };
 
 Controller.prototype._onPortData = function(line) {

--- a/lib/Controller.js
+++ b/lib/Controller.js
@@ -1,9 +1,9 @@
-var events = require('events'),
-    fs     = require('fs'),
-    moment = require('moment'),
-    path   = require('path'),
-    serial = require('serialport'),
-    util   = require('util');
+var events     = require('events'),
+    fs         = require('fs'),
+    moment     = require('moment'),
+    path       = require('path'),
+    SerialPort = require('serialport'),
+    util       = require('util');
 
 var PID = require('./pid');
 
@@ -28,9 +28,9 @@ function Controller(settings) {
 
     self.history = [];
 
-    self.port = new serial.SerialPort(settings.deviceName, {
+    self.port = new SerialPort(settings.deviceName, {
         baudRate : 115200,
-        parser   : serial.parsers.readline('\n')
+        parser   : SerialPort.parsers.readline('\n')
     });
 
     self.port.on('open', self._onPortOpen.bind(self));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "express"     : "^4.13.4",
         "js-yaml"     : "^3.6.1",
         "moment"      : "^2.13.0",
-        "serialport"  : "^3.1.2",
+        "serialport"  : "^4.0.7",
         "split"       : "^1.0.0"
     }
 }


### PR DESCRIPTION
This PR adds error logging when sending serial commands, and upgrades the version of the `serialport` library.

I don't remember which version of Node.js is running on this device.  If it's 6.x or newer, we can upgrade `serialport` again:  https://github.com/EmergingTechnologyAdvisors/node-serialport#for-which-version-of-node-serialport-would-you-like-documentation