### PR TITLE
Add the ability to set an explicit ramp start temperature

### DIFF
--- a/lib/Scheduler.js
+++ b/lib/Scheduler.js
@@ -75,14 +75,10 @@ Scheduler.prototype.update = function() {
 
     if (minutesThisStep < step.rampMinutes) {
         // Ramp
-        var previousTemperature = (
-            self.status.stepIndex > 0
-                ? self.schedule[self.status.stepIndex - 1].temperature
-                : self.settings.minTemperature
-        );
+        var startTemperature = step.rampStartTemperature;
         desiredTemperature = (
-            previousTemperature +
-            (step.temperature - previousTemperature) * (minutesThisStep / step.rampMinutes)
+            startTemperature +
+            (step.temperature - startTemperature) * (minutesThisStep / step.rampMinutes)
         );
     } else if (minutesThisStep < step.rampMinutes + step.soakMinutes) {
         // Soak
@@ -153,8 +149,8 @@ Scheduler.prototype.validateSchedule = function(schedule) {
     schedule.forEach(function(step) {
         if (
             typeof step.temperature !== 'number' ||
-            schedule.temperature < self.settings.minTemperature ||
-            schedule.temperature > self.settings.maxTemperature
+            step.temperature < self.settings.minTemperature ||
+            step.temperature > self.settings.maxTemperature
         ) {
             throw new Error(util.format(
                 'Step temperature must be a number between %d and %d',
@@ -188,6 +184,26 @@ Scheduler.prototype.validateSchedule = function(schedule) {
 
         if (step.rampMinutes === 0 && step.soakMinutes === 0) {
             throw new Error('Step ramp and soak times cannot both be zero');
+        }
+
+        if (step.rampMinutes > 0) {
+            if (typeof step.rampStartTemperature === 'undefined') {
+                step.rampStartTemperature = self.settings.minTemperature;
+            }
+
+            if (
+                typeof step.rampStartTemperature !== 'number' ||
+                step.rampStartTemperature < self.settings.minTemperature ||
+                step.rampStartTemperature > self.settings.maxTemperature
+            ) {
+                throw new Error(util.format(
+                    'Step temperature must be a number between %d and %d',
+                    self.settings.minTemperature,
+                    self.settings.maxTemperature
+                ));
+            }
+        } else {
+            delete step.rampStartTemperature;
         }
     });
 

--- a/lib/Scheduler.js
+++ b/lib/Scheduler.js
@@ -146,7 +146,7 @@ Scheduler.prototype.validateSchedule = function(schedule) {
         throw new Error('Schedule must have at least one step');
     }
 
-    schedule.forEach(function(step) {
+    schedule.forEach(function(step, index) {
         if (
             typeof step.temperature !== 'number' ||
             step.temperature < self.settings.minTemperature ||
@@ -188,7 +188,11 @@ Scheduler.prototype.validateSchedule = function(schedule) {
 
         if (step.rampMinutes > 0) {
             if (typeof step.rampStartTemperature === 'undefined') {
-                step.rampStartTemperature = self.settings.minTemperature;
+                if (index === 0) {
+                    step.rampStartTemperature = self.settings.minTemperature;
+                } else {
+                    step.rampStartTemperature = schedule[index - 1].temperature;
+                }
             }
 
             if (


### PR DESCRIPTION
Schedule steps now have an optional `rampStartTemperature` parameter which controls the starting temperature of the ramp and defaults to the minimum temperature (for the first step) or the previous step's temperature (for subsequent steps).

Also fix a bug when validating step temperatures.